### PR TITLE
feat: add frame canvas

### DIFF
--- a/src/components/buttons/liquid-glass/index.tsx
+++ b/src/components/buttons/liquid-glass/index.tsx
@@ -1,0 +1,70 @@
+import { cn } from '@/lib/utils';
+import { FC, ReactNode } from 'react';
+
+type LiquidGlassButtonProps = {
+  children: ReactNode;
+  onClick?: (e?: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
+  size?: 'sm' | 'md' | 'lg';
+  variant?: 'default' | 'subtle';
+  disabled?: boolean;
+  style?: React.CSSProperties;
+};
+
+const LiquidGlassButton: FC<LiquidGlassButtonProps> = ({
+  children,
+  onClick,
+  className,
+  size = 'md',
+  variant = 'default',
+  disabled = false,
+  style,
+}) => {
+  const sizeClasses = {
+    sm: 'px-2 py-1 text-xs rounded-lg',
+    md: 'px-3 py-2 text-sm rounded-xl',
+    lg: 'px-4 py-3 text-base rounded-2xl',
+  };
+
+  const variantClasses = {
+    default: 'backdrop-blur-xl bg-white/[0.08] border border-white/[0.12] saturate-150',
+    subtle: 'backdrop-blur-lg bg-white/[0.05] border border-white/[0.08] saturate-125',
+  };
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      style={style}
+      className={cn(
+        // Base styles
+        'relative transition-all duration-200 ease-out whitespace-nowrap',
+        'text-white/90 font-medium',
+        'flex items-center gap-2',
+        'pointer-events-auto cursor-pointer',
+
+        // Glass morphic effect
+        variantClasses[variant],
+
+        // Size variants
+        sizeClasses[size],
+
+        // Interact states
+        'hover:bg-white/[0.12] hover:border-white/[0.16]',
+        'active:bg-white/[0.06] active:scale-[0.98]',
+        'focus:outline-none focus:ring-2 focus: ring-white/20 focus:ring-offset-2 focus:ring-offset-transparent',
+
+        // Disabled state
+        disabled &&
+          'opacity-50 cursor-not-allowed hover:bg-white/[0.08] hover:border-white/[0.12] active:scale-100',
+
+        // Custom classes
+        className,
+      )}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default LiquidGlassButton;

--- a/src/components/buttons/liquid-glass/index.tsx
+++ b/src/components/buttons/liquid-glass/index.tsx
@@ -1,14 +1,14 @@
 import { cn } from '@/lib/utils';
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, MouseEvent, CSSProperties } from 'react';
 
 type LiquidGlassButtonProps = {
   children: ReactNode;
-  onClick?: (e?: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick?: (e?: MouseEvent<HTMLButtonElement>) => void;
   className?: string;
   size?: 'sm' | 'md' | 'lg';
   variant?: 'default' | 'subtle';
   disabled?: boolean;
-  style?: React.CSSProperties;
+  style?: CSSProperties;
 };
 
 const LiquidGlassButton: FC<LiquidGlassButtonProps> = ({
@@ -52,7 +52,7 @@ const LiquidGlassButton: FC<LiquidGlassButtonProps> = ({
         // Interact states
         'hover:bg-white/[0.12] hover:border-white/[0.16]',
         'active:bg-white/[0.06] active:scale-[0.98]',
-        'focus:outline-none focus:ring-2 focus: ring-white/20 focus:ring-offset-2 focus:ring-offset-transparent',
+        'focus:outline-none focus:ring-2 focus:ring-white/20 focus:ring-offset-2 focus:ring-offset-transparent',
 
         // Disabled state
         disabled &&

--- a/src/components/canvas/index.tsx
+++ b/src/components/canvas/index.tsx
@@ -62,7 +62,7 @@ const InfiniteCanvas: FC = () => {
           }}
         >
           {shapes.map((shape) => (
-            <ShapeRenderer key={`render-${shape.id}`} shape={shape} />
+            <ShapeRenderer key={`render-${shape.id}`} shape={shape} toggleInspiration={() => {}} />
           ))}
 
           {shapes.map((shape) => (

--- a/src/components/canvas/shapes/frame/index.tsx
+++ b/src/components/canvas/shapes/frame/index.tsx
@@ -1,0 +1,74 @@
+import { FC, Fragment } from 'react';
+import { Brush, Palette } from 'lucide-react';
+import { FrameShape } from '@/redux/slice/shapes';
+import LiquidGlassButton from '@/components/buttons/liquid-glass';
+import { useFrame } from '@/hooks/use-frame';
+
+type FrameComponentProps = {
+  shape: FrameShape;
+  toggleInspiration?: () => void;
+};
+
+const FrameComponent: FC<FrameComponentProps> = ({ shape, toggleInspiration }) => {
+  const { isGenerating, handleGenerateDesign } = useFrame(shape);
+
+  return (
+    <Fragment>
+      <div
+        className="absolute pointer-events-none backdrop-blur-xl bg-white/[0.08] border border-white/[0.12] saturate-150"
+        style={{
+          left: shape.x,
+          top: shape.y,
+          width: shape.w,
+          height: shape.h,
+          borderRadius: '12px', // Slightly more rounded for modern feel
+        }}
+      />
+      <div
+        className="absolute pointer-events-none whitespace-nowrap text-xs font-medium text-white/80 select-none"
+        style={{
+          left: shape.x,
+          top: shape.y - 24, // Position above the frame
+          fontSize: '11px',
+          lineHeight: '1.2',
+        }}
+      >
+        Frame {shape.frameNumber}
+      </div>
+      <div
+        className="absolute pointer-events-auto flex gap-4"
+        style={{
+          left: shape.x + shape.w - 235, // Position at top right, accounting for button width
+          top: shape.y - 36, // Position above the frame with some spacing
+          zIndex: 1000, // Ensure button is on top
+        }}
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <LiquidGlassButton
+          size="sm"
+          variant="subtle"
+          onClick={toggleInspiration}
+          style={{ pointerEvents: 'auto' }}
+        >
+          <Palette size={12} />
+          Inspiration
+        </LiquidGlassButton>
+        <LiquidGlassButton
+          size="sm"
+          variant="subtle"
+          onClick={handleGenerateDesign}
+          disabled={isGenerating}
+          className={isGenerating ? 'animate-pulse' : ''}
+          style={{ pointerEvents: 'auto' }}
+        >
+          <Brush size={12} className={isGenerating ? 'animate-spin' : ''} />
+          {isGenerating ? 'Generating...' : 'Generate Design'}
+        </LiquidGlassButton>
+      </div>
+    </Fragment>
+  );
+};
+
+export default FrameComponent;

--- a/src/components/canvas/shapes/frame/preview.tsx
+++ b/src/components/canvas/shapes/frame/preview.tsx
@@ -1,0 +1,30 @@
+import { Point } from '@/redux/slice/viewport';
+import { FC } from 'react';
+
+type FramePreviewProps = {
+  startWorld: Point;
+  currentWorld: Point;
+};
+
+const FramePreview: FC<FramePreviewProps> = ({ startWorld, currentWorld }) => {
+  const x = Math.min(startWorld.x, currentWorld.x);
+  const y = Math.min(startWorld.y, currentWorld.y);
+  const w = Math.abs(currentWorld.x - startWorld.x);
+  const h = Math.abs(currentWorld.y - startWorld.y);
+
+  return (
+    <div
+      className="absolute pointer-events-none border-2 border-dashed border-gray-400"
+      style={{
+        left: x,
+        top: y,
+        width: w,
+        height: h,
+        backgroundColor: 'rgba(255, 255, 255, 0.08)', // Semi-transparent preview matching toolbar
+        borderRadius: '8px', // Rounded borders to match final frame
+      }}
+    />
+  );
+};
+
+export default FramePreview;

--- a/src/components/canvas/shapes/index.tsx
+++ b/src/components/canvas/shapes/index.tsx
@@ -8,10 +8,11 @@ import RectangleComponent from './rectangle';
 import StrokeComponent from './stroke';
 import LineComponent from './line';
 import TextComponent from './text';
+import FrameComponent from './frame';
 
 type ShapeRendererProps = {
   shape: Shape;
-  // toggleInspiration: () => void;
+  toggleInspiration: () => void;
   // toggleChat: (generatedUIId: string) => void;
   // generateWorkflow: (generatedUIId: string) => void;
   // exportDesign: (generatedUIId: string, element: HTMLElement | null) => void;
@@ -19,12 +20,14 @@ type ShapeRendererProps = {
 
 const ShapeRenderer: FC<ShapeRendererProps> = ({
   shape,
-  // toggleInspiration,
+  toggleInspiration,
   // toggleChat,
   // generateWorkflow,
   // exportDesign,
 }) => {
   switch (shape.type) {
+    case 'frame':
+      return <FrameComponent shape={shape} toggleInspiration={toggleInspiration} />;
     case 'rect':
       return <RectangleComponent shape={shape} />;
     case 'ellipse':

--- a/src/components/canvas/toolbar/zoom/index.tsx
+++ b/src/components/canvas/toolbar/zoom/index.tsx
@@ -92,7 +92,7 @@ const ZoomBar: FC = () => {
           size="lg"
           onClick={handleZoomIn}
           className="w-9 h-9 p-0 rounded-full cursor-pointer hover:bg-white/[0.12] border border-transparent hover:border-white/[0.16] transition-all"
-          title="Zoom Out"
+          title="Zoom In"
         >
           <ZoomIn className="w-4 h-4 text-primary/50" />
         </Button>

--- a/src/hooks/use-frame.ts
+++ b/src/hooks/use-frame.ts
@@ -1,0 +1,40 @@
+import { useCallback, useMemo, useState } from 'react';
+import { FrameShape, Shape } from '@/redux/slice/shapes';
+import { useAppDispatch, useAppSelector } from '@/redux/store';
+import { downloadBlob, generateFrameSnapshot } from '@/lib/frame-snapshot';
+
+export const useFrame = (shape: FrameShape) => {
+  const dispatch = useAppDispatch();
+  const [isGenerating, setIsGenerating] = useState<boolean>(false);
+
+  const entityState = useAppSelector((s) => s.shapes.shapes.entities);
+  const allShapes: Shape[] = useMemo(
+    () => Object.values(entityState).filter((s: Shape): s is Shape => s !== undefined),
+    [entityState],
+  );
+
+  const handleGenerateDesign = useCallback(async () => {
+    try {
+      setIsGenerating(true);
+      const snapshot = await generateFrameSnapshot(shape, allShapes);
+
+      downloadBlob(snapshot, `frame-${shape.frameNumber}-snapshot.png`);
+
+      const formData = new FormData();
+      formData.append('image', snapshot, `frame-${shape.frameNumber}.png`);
+      formData.append('frameNumber', shape.frameNumber.toString());
+
+      const urlParams = new URLSearchParams(window.location.search);
+      const projectId = urlParams.get('projectId');
+
+      if (projectId) {
+        formData.append('projectId', projectId);
+      }
+    } catch (error) {}
+  }, [allShapes, shape]);
+
+  return {
+    isGenerating,
+    handleGenerateDesign,
+  };
+};

--- a/src/hooks/use-frame.ts
+++ b/src/hooks/use-frame.ts
@@ -30,7 +30,11 @@ export const useFrame = (shape: FrameShape) => {
       if (projectId) {
         formData.append('projectId', projectId);
       }
-    } catch (error) {}
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsGenerating(false);
+    }
   }, [allShapes, shape]);
 
   return {

--- a/src/lib/frame-snapshot.ts
+++ b/src/lib/frame-snapshot.ts
@@ -210,8 +210,9 @@ export const generateFrameSnapshot = async (
       (blob) => {
         if (blob) {
           resolve(blob);
+        } else {
+          reject(new Error('Failed to create image blob'));
         }
-        reject(new Error('Failed to create image blob'));
       },
       'image/png',
       1.0,

--- a/src/lib/frame-snapshot.ts
+++ b/src/lib/frame-snapshot.ts
@@ -43,7 +43,7 @@ export const isShapeInsideFrame = (shape: Shape, frame: FrameShape): boolean => 
     case 'arrow':
       // Check if either start or end point is within frame
       const startInside = _isShapeInsideFrame({ x: shape.startX, y: shape.startY });
-      const endInside = _isShapeInsideFrame({ x: shape.startX, y: shape.startY });
+      const endInside = _isShapeInsideFrame({ x: shape.endX, y: shape.endY });
 
       return startInside || endInside;
     default:

--- a/src/lib/frame-snapshot.ts
+++ b/src/lib/frame-snapshot.ts
@@ -1,0 +1,231 @@
+import { FrameShape, Shape } from '@/redux/slice/shapes';
+import { Point } from '@/redux/slice/viewport';
+
+const _checkFrameByCoordinate = (
+  frame: FrameShape,
+): { _isShapeInsideFrame: (p: Point) => boolean } => {
+  const frameLeft = frame.x;
+  const frameTop = frame.y;
+  const frameRight = frame.x + frame.w;
+  const frameBottom = frame.y + frame.h;
+
+  return {
+    _isShapeInsideFrame: ({ x, y }: Point) =>
+      x >= frameLeft && x <= frameRight && y >= frameTop && y <= frameBottom,
+  };
+};
+
+export const isShapeInsideFrame = (shape: Shape, frame: FrameShape): boolean => {
+  const { _isShapeInsideFrame } = _checkFrameByCoordinate(frame);
+
+  switch (shape.type) {
+    case 'rect':
+    case 'ellipse':
+    case 'frame':
+      // Check if shape center pointer is within frame
+      const centerX = shape.x + shape.w / 2;
+      const centerY = shape.y + shape.h / 2;
+      return _isShapeInsideFrame({
+        x: centerX,
+        y: centerY,
+      });
+
+    case 'text':
+      // Check if text position is within frame
+      return _isShapeInsideFrame({
+        x: shape.x,
+        y: shape.y,
+      });
+    case 'free-draw':
+      // Check if any drawing points are within frame
+      return shape.points.some(_isShapeInsideFrame);
+    case 'line':
+    case 'arrow':
+      // Check if either start or end point is within frame
+      const startInside = _isShapeInsideFrame({ x: shape.startX, y: shape.startY });
+      const endInside = _isShapeInsideFrame({ x: shape.startX, y: shape.startY });
+
+      return startInside || endInside;
+    default:
+      return false;
+  }
+};
+
+export const getShapesInsideFrame = (shapes: Shape[], frame: FrameShape): Shape[] => {
+  // Simple coordinate-based detection: find shapes within frame bounds
+  const shapesInFrame = shapes.filter(
+    (shape) => shape.id !== frame.id && isShapeInsideFrame(shape, frame),
+  );
+
+  console.log(`Frame ${frame.frameNumber} capture:`, {
+    totalShapes: shapes.length,
+    captured: shapesInFrame.length,
+    capturedTypes: shapesInFrame.map((s) => s.type),
+  });
+
+  return shapesInFrame;
+};
+
+const _renderShapeOnCanvas = (
+  ctx: CanvasRenderingContext2D,
+  shape: Shape,
+  frameX: number,
+  frameY: number,
+) => {
+  ctx.save();
+
+  switch (shape.type) {
+    case 'frame':
+    case 'rect':
+    case 'ellipse': {
+      const relativeX = shape.x - frameX;
+      const relativeY = shape.y - frameY;
+
+      ctx.strokeStyle = shape.stroke && shape.stroke !== 'transparent' ? shape.stroke : '#ffffff';
+      ctx.lineWidth = shape.strokeWidth || 2;
+
+      const borderRadius = shape.type === 'rect' ? 8 : 0;
+      ctx.beginPath();
+
+      if (shape.type === 'ellipse') {
+        ctx.ellipse(
+          relativeX + shape.w / 2,
+          relativeY + shape.h / 2,
+          shape.w / 2,
+          shape.h / 2,
+          0,
+          0,
+          2 * Math.PI,
+        );
+      } else {
+        ctx.roundRect(relativeX, relativeY, shape.w, shape.h, borderRadius);
+      }
+
+      ctx.stroke();
+      break;
+    }
+    case 'text': {
+      const textRelativeX = shape.x - frameX;
+      const textRelativeY = shape.y - frameY;
+
+      ctx.fillStyle = shape.fill || '#ffffff';
+      ctx.font = `${shape.fontSize}px ${shape.fontFamily || 'Inter, sans-serif'}`;
+      ctx.textBaseline = 'top';
+      ctx.fillText(shape.text, textRelativeX, textRelativeY);
+      break;
+    }
+    case 'free-draw': {
+      if (shape.points.length > 1) {
+        ctx.strokeStyle = shape.stroke || '#ffffff';
+        ctx.lineWidth = shape.strokeWidth || 2;
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+        ctx.beginPath();
+
+        const firstPoint = shape.points[0];
+        ctx.moveTo(firstPoint.x - frameX, firstPoint.y - frameY);
+
+        for (let i = 1; i < shape.points.length; i++) {
+          const point = shape.points[i];
+          ctx.lineTo(point.x - frameX, point.y - frameY);
+        }
+
+        ctx.stroke();
+      }
+      break;
+    }
+    case 'line': {
+      ctx.strokeStyle = shape.stroke || '#ffffff';
+      ctx.lineWidth = shape.strokeWidth || 2;
+      ctx.beginPath();
+
+      ctx.moveTo(shape.startX - frameX, shape.startY - frameY);
+      ctx.lineTo(shape.endX - frameX, shape.endY - frameY);
+      ctx.stroke();
+
+      break;
+    }
+    case 'arrow': {
+      ctx.strokeStyle = shape.stroke || '#ffffff';
+      ctx.lineWidth = shape.strokeWidth || 2;
+      ctx.beginPath();
+
+      ctx.moveTo(shape.startX - frameX, shape.startY - frameY);
+      ctx.lineTo(shape.endX - frameX, shape.endY - frameY);
+      ctx.stroke();
+
+      const headLength = 10;
+      const angle = Math.atan2(shape.endY - shape.startY, shape.endX - shape.startX);
+      ctx.fillStyle = shape.stroke || '#ffffff';
+      ctx.beginPath();
+
+      ctx.moveTo(shape.endX - frameX, shape.endY - frameY);
+      ctx.lineTo(
+        shape.endX - frameX - headLength * Math.cos(angle - Math.PI / 6),
+        shape.endY - frameY - headLength * Math.sin(angle - Math.PI / 6),
+      );
+      ctx.lineTo(
+        shape.endX - frameX - headLength * Math.cos(angle + Math.PI / 6),
+        shape.endY - frameY - headLength * Math.sin(angle + Math.PI / 6),
+      );
+      ctx.closePath();
+      ctx.fill();
+      break;
+    }
+  }
+  ctx.restore();
+};
+
+export const generateFrameSnapshot = async (
+  frame: FrameShape,
+  allShapes: Shape[],
+): Promise<Blob> => {
+  const shapesInFrame = getShapesInsideFrame(allShapes, frame);
+  const canvas = document.createElement('canvas');
+  canvas.width = frame.w;
+  canvas.height = frame.h;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Failed to get canvas context');
+  }
+
+  ctx.fillStyle = '#000000';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.save();
+
+  ctx.beginPath();
+  ctx.rect(0, 0, canvas.width, canvas.height);
+  ctx.clip();
+
+  shapesInFrame.forEach((shape) => {
+    _renderShapeOnCanvas(ctx, shape, frame.x, frame.y);
+  });
+
+  ctx.restore();
+  console.log('✅ All shapes rendered');
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob);
+        }
+        reject(new Error('Failed to create image blob'));
+      },
+      'image/png',
+      1.0,
+    );
+  });
+};
+
+export const downloadBlob = (blob: Blob, filename: string): void => {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
    

## Summary
Adds a Frame shape to the canvas with a preview, toolbar actions, and snapshot export to PNG. Integrates frame rendering into the canvas and adds a reusable glass-style button.

- **New Features**
  - Frame shape with labeled glass frame UI and top-right actions.
  - Drag preview while creating a frame.
  - Generate Design: captures shapes inside the frame to a PNG via canvas and downloads it.
  - Inspiration button hook wired into the frame component.
  - New LiquidGlassButton component for subtle glass buttons.
  - ShapeRenderer updated to support the new frame type.

- **Bug Fixes**
  - Corrected zoom control tooltip from “Zoom Out” to “Zoom In”.



